### PR TITLE
Add per-toggle customization and 'q' key shortcut

### DIFF
--- a/Theme.qml
+++ b/Theme.qml
@@ -23,14 +23,19 @@ QtObject {
     readonly property color barBorder: _get("barBorder", Qt.rgba(1, 1, 1, 0.15))
     readonly property color barText: _get("barText", "#AAFFFFFF")
     readonly property color barShadow: _get("barShadow", "#80000000")
-    readonly property color toggleBackground: _get("toggleBackground", "white")
-    readonly property color toggleShadow: _get("toggleShadow", "#80000000")
     readonly property color toggleEdit: _get("toggleEdit", "#1ABC9C")
+    readonly property color toggleEditBackground: _get("toggleEditBackground", "white")
+    readonly property color toggleEditShadow: _get("toggleEditShadow", "#80000000")
     readonly property color toggleTemp: _get("toggleTemp", "#2C66D8")
+    readonly property color toggleTempBackground: _get("toggleTempBackground", "white")
+    readonly property color toggleTempShadow: _get("toggleTempShadow", "#80000000")
+    readonly property color toggleShareBackground: _get("toggleShareBackground", "white")
+    readonly property color toggleShareShadow: _get("toggleShareShadow", "#80000000")
     readonly property color shareConnected: _get("shareConnected", "#3498DB")
     readonly property color sharePending: _get("sharePending", "#95A5A6")
     readonly property color shareErrorIcon: _get("shareErrorIcon", "white")
     readonly property color shareErrorBackground: _get("shareErrorBackground", "#E74C3C")
+    readonly property color shareErrorShadow: _get("shareErrorShadow", "#80000000")
     readonly property string postSaveHook: source.hooksPostSaveHook || ""
 
     function _get(key, fallback) {

--- a/shell.qml
+++ b/shell.qml
@@ -251,6 +251,14 @@ FreezeScreen {
     }
 
     Shortcut {
+        sequence: "q"
+        onActivated: {
+            cleanup();
+            Qt.quit();
+        }
+    }
+
+    Shortcut {
         sequence: "r"
         onActivated: root.mode = "region"
     }
@@ -523,8 +531,8 @@ FreezeScreen {
         active: root.editActive
         icon: "󰏫"
         iconColor: theme.toggleEdit
-        backgroundColor: theme.toggleBackground
-        shadowColor: theme.toggleShadow
+        backgroundColor: theme.toggleEditBackground
+        shadowColor: theme.toggleEditShadow
         targetX: (root.width - root.targetMenuWidth) / 2 - 15 - width
         targetY: segmentedControl.y + segmentedControl.height / 2
         sourceX: root.width / 2 - 204 + 32
@@ -537,8 +545,8 @@ FreezeScreen {
         active: root.tempActive
         icon: "󰅇"
         iconColor: theme.toggleTemp
-        backgroundColor: theme.toggleBackground
-        shadowColor: theme.toggleShadow
+        backgroundColor: theme.toggleTempBackground
+        shadowColor: theme.toggleTempShadow
         targetX: (root.width + root.targetMenuWidth) / 2 + 15
         targetY: segmentedControl.y + segmentedControl.height / 2
         sourceX: root.width / 2 - 204 + 332
@@ -559,8 +567,8 @@ FreezeScreen {
 
             return theme.sharePending;
         }
-        backgroundColor: root.connectivityStatus === 2 ? theme.shareErrorBackground : theme.toggleBackground
-        shadowColor: theme.toggleShadow
+        backgroundColor: root.connectivityStatus === 2 ? theme.shareErrorBackground : theme.toggleShareBackground
+        shadowColor: root.connectivityStatus === 2 ? theme.shareErrorShadow : theme.toggleShareShadow
         pulse: root.connectivityStatus === 0
         targetX: (root.width + root.targetMenuWidth) / 2 + 15 + (root.tempActive ? 44 + 10 : 0)
         targetY: segmentedControl.y + segmentedControl.height / 2

--- a/theme.toml
+++ b/theme.toml
@@ -29,14 +29,22 @@ text = "#AAFFFFFF"
 shadow = "#80000000"
 
 [toggle]
-# Pill background for edit/temp/share buttons
-background = "white"
-# Drop shadow under toggle pills
-shadow = "#80000000"
 # Edit toggle icon color
 edit = "#1ABC9C"
+# Edit toggle background
+editBackground = "white"
+# Edit toggle shadow
+editShadow = "#80000000"
 # Temp toggle icon color
 temp = "#2C66D8"
+# Temp toggle background
+tempBackground = "white"
+# Temp toggle shadow
+tempShadow = "#80000000"
+# Share toggle background (when connected/pending)
+shareBackground = "white"
+# Share toggle shadow
+shareShadow = "#80000000"
 
 [share]
 # Icon color when device is reachable
@@ -47,6 +55,8 @@ pending = "#95A5A6"
 errorIcon = "white"
 # Background color on connection failure
 errorBackground = "#E74C3C"
+# Shadow color on connection failure
+errorShadow = "#80000000"
 
 [hooks]
 # Command to run after a screenshot is saved (leave empty to disable)


### PR DESCRIPTION
- Add individual background and shadow options for each toggle pill
- Replace shared toggle.background/shadow with per-toggle properties
- Add toggleEditBackground, toggleEditShadow, toggleTempBackground, toggleTempShadow, toggleShareBackground, toggleShareShadow, shareErrorShadow
- Add 'q' key shortcut to quit utility (in addition to Escape)