### PR TITLE
Fix on GIt Quickshell

### DIFF
--- a/components/FreezeScreen.qml
+++ b/components/FreezeScreen.qml
@@ -35,12 +35,14 @@ PanelWindow {
 
     property var targetScreen: Quickshell.screens[0]
     property bool grabKeyboard: false
+    property bool isReady: false
     property alias contentItem: root.contentItem
 
     screen: targetScreen
     exclusionMode: ExclusionMode.Ignore
     WlrLayershell.layer: WlrLayer.Overlay
     WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+    color: "transparent"
 
     anchors {
         left: true
@@ -54,5 +56,11 @@ PanelWindow {
         anchors.fill: parent
         z: -1
     }
-
+    Timer {
+        interval: 100
+        running: true
+        onTriggered: {
+            root.isReady = true;
+        }
+    }
 }

--- a/shell.qml
+++ b/shell.qml
@@ -400,7 +400,7 @@ Scope {
             RegionSelector {
                 id: regionSelector
 
-                visible: root.mode === "region"
+                visible: root.mode === "region" && overlay.isReady
                 anchors.fill: parent
                 dimOpacity: overlay.themeRef.dimOpacity
                 borderRadius: overlay.themeRef.borderRadius
@@ -429,7 +429,7 @@ Scope {
             ControlBar {
                 id: segmentedControl
 
-                visible: overlay.isFocused
+                visible: overlay.isFocused && overlay.isReady
                 modes: root.modes
                 mode: root.mode
                 tempActive: root.tempActive


### PR DESCRIPTION
Recently this tool shows a grey screen on git Quickshell. Unsure of the quickshell commit that caused this, but after diagnosing the problem is like this:
- Screencopy is run asynchronously, only getting a frame ~80ms later
- PanelWindow is opaque by default (white)
- This causes a the user to not be able to see the screen when screenshotting.

This PR is a sketchy solution to these. The PanelWindow's color is set to "transparent", this is fine.
However, because the Screencopy lags, it captures the dimming and toolbars in the preview. To circumvent this, we delay the toolbars and dimming by using a isReady timer.

I think there may be a more elegant solution than this, but it works well enough for me! Feel free to make any changes.