### PR TITLE
Skip the upfront grim capture

### DIFF
--- a/components/RegionSelector.qml
+++ b/components/RegionSelector.qml
@@ -69,13 +69,6 @@ Item {
         guides.requestPaint();
     }
 
-    onSelectionXChanged: guides.requestPaint()
-    onSelectionYChanged: guides.requestPaint()
-    onSelectionWidthChanged: guides.requestPaint()
-    onSelectionHeightChanged: guides.requestPaint()
-    onMouseXChanged: guides.requestPaint()
-    onMouseYChanged: guides.requestPaint()
-
     ShaderEffect {
         property vector4d selectionRect: Qt.vector4d(root.selectionX, root.selectionY, root.selectionWidth, root.selectionHeight)
         property real dimOpacity: root.dimOpacity
@@ -88,34 +81,61 @@ Item {
         fragmentShader: root.fragmentShader
     }
 
-    Canvas {
+    Item {
         id: guides
-
         anchors.fill: parent
         z: 2
-        onPaint: {
-            var ctx = getContext("2d");
-            ctx.clearRect(0, 0, width, height);
-            ctx.beginPath();
-            ctx.strokeStyle = "rgba(255, 255, 255, 0.5)";
-            ctx.lineWidth = 1;
-            ctx.setLineDash([5, 5]);
-            if (!root.selecting) {
-                ctx.moveTo(root.mouseX, 0);
-                ctx.lineTo(root.mouseX, root.height);
-                ctx.moveTo(0, root.mouseY);
-                ctx.lineTo(root.width, root.mouseY);
-            } else {
-                ctx.moveTo(root.selectionX, 0);
-                ctx.lineTo(root.selectionX, root.height);
-                ctx.moveTo(root.selectionX + root.selectionWidth, 0);
-                ctx.lineTo(root.selectionX + root.selectionWidth, root.height);
-                ctx.moveTo(0, root.selectionY);
-                ctx.lineTo(root.width, root.selectionY);
-                ctx.moveTo(0, root.selectionY + root.selectionHeight);
-                ctx.lineTo(root.width, root.selectionY + root.selectionHeight);
-            }
-            ctx.stroke();
+
+        readonly property color guideColor: Qt.rgba(1, 1, 1, 0.5)
+
+        Rectangle {
+            visible: !root.selecting
+            color: guides.guideColor
+            x: root.mouseX
+            y: 0
+            width: 1
+            height: parent.height
+        }
+        Rectangle {
+            visible: !root.selecting
+            color: guides.guideColor
+            x: 0
+            y: root.mouseY
+            width: parent.width
+            height: 1
+        }
+
+        Rectangle {
+            visible: root.selecting
+            color: guides.guideColor
+            x: root.selectionX
+            y: 0
+            width: 1
+            height: parent.height
+        }
+        Rectangle {
+            visible: root.selecting
+            color: guides.guideColor
+            x: root.selectionX + root.selectionWidth
+            y: 0
+            width: 1
+            height: parent.height
+        }
+        Rectangle {
+            visible: root.selecting
+            color: guides.guideColor
+            x: 0
+            y: root.selectionY
+            width: parent.width
+            height: 1
+        }
+        Rectangle {
+            visible: root.selecting
+            color: guides.guideColor
+            x: 0
+            y: root.selectionY + root.selectionHeight
+            width: parent.width
+            height: 1
         }
     }
 
@@ -210,7 +230,7 @@ Item {
     }
 
     Behavior on selectionX {
-        enabled: root.animateSelection && root.globalAnimations
+        enabled: root.animateSelection && root.globalAnimations && !root.selecting
 
         // Selection animations using spring dynamics
         SpringAnimation {
@@ -221,7 +241,7 @@ Item {
     }
 
     Behavior on selectionY {
-        enabled: root.animateSelection && root.globalAnimations
+        enabled: root.animateSelection && root.globalAnimations && !root.selecting
 
         SpringAnimation {
             spring: 4
@@ -231,7 +251,7 @@ Item {
     }
 
     Behavior on selectionWidth {
-        enabled: root.animateSelection && root.globalAnimations
+        enabled: root.animateSelection && root.globalAnimations && !root.selecting
 
         SpringAnimation {
             spring: 4
@@ -241,7 +261,7 @@ Item {
     }
 
     Behavior on selectionHeight {
-        enabled: root.animateSelection && root.globalAnimations
+        enabled: root.animateSelection && root.globalAnimations && !root.selecting
 
         SpringAnimation {
             spring: 4

--- a/components/WindowSelector.qml
+++ b/components/WindowSelector.qml
@@ -36,107 +36,99 @@ Item {
     property var workspace: monitor?.activeWorkspace
     property var windows: workspace?.toplevels ?? []
 
-    signal checkHover(real mouseX, real mouseY)
-    signal regionSelected(real x, real y, real width, real height)  
+    signal regionSelected(real x, real y, real width, real height)
     property alias pressed: mouseArea.pressed
 
     property real mouseX: 0
     property real mouseY: 0
-    onMouseXChanged: checkHover(mouseX, mouseY)
-    onMouseYChanged: checkHover(mouseX, mouseY)
-      
-    property real dimOpacity: 0.6  
-    property real borderRadius: 10.0  
-    property real outlineThickness: 2.0  
-    property url fragmentShader: Qt.resolvedUrl("../shaders/dimming.frag.qsb")  
-      
-    property point startPos  
-    property real selectionX: 0  
-    property real selectionY: 0  
-    property real selectionWidth: 0  
-    property real selectionHeight: 0  
-      
+    onMouseXChanged: updateHovered()
+    onMouseYChanged: updateHovered()
+
+    property real dimOpacity: 0.6
+    property real borderRadius: 10.0
+    property real outlineThickness: 2.0
+    property url fragmentShader: Qt.resolvedUrl("../shaders/dimming.frag.qsb")
+
+    property real selectionX: 0
+    property real selectionY: 0
+    property real selectionWidth: 0
+    property real selectionHeight: 0
+
     property bool animateSelection: true
+
+    function hitWindow(mx, my) {
+        if (!monitor || !monitor.lastIpcObject)
+            return null;
+        const mx0 = monitor.lastIpcObject.x;
+        const my0 = monitor.lastIpcObject.y;
+        const list = windows;
+        for (let i = list.length - 1; i >= 0; i--) {
+            const w = list[i];
+            if (!w || !w.lastIpcObject) continue;
+            const wx = w.lastIpcObject.at[0] - mx0;
+            const wy = w.lastIpcObject.at[1] - my0;
+            const ww = w.lastIpcObject.size[0];
+            const wh = w.lastIpcObject.size[1];
+            if (mx >= wx && mx <= wx + ww && my >= wy && my <= wy + wh) {
+                return { x: wx, y: wy, w: ww, h: wh };
+            }
+        }
+        return null;
+    }
+
+    function updateHovered() {
+        const hit = hitWindow(mouseX, mouseY);
+        if (!hit) return;
+        selectionX = hit.x;
+        selectionY = hit.y;
+        selectionWidth = hit.w;
+        selectionHeight = hit.h;
+    }
 
     Behavior on selectionX { enabled: root.animateSelection; SpringAnimation { spring: 4; damping: 0.4 } }
     Behavior on selectionY { enabled: root.animateSelection; SpringAnimation { spring: 4; damping: 0.4 } }
     Behavior on selectionHeight { enabled: root.animateSelection; SpringAnimation { spring: 4; damping: 0.4 } }
-    Behavior on selectionWidth { enabled: root.animateSelection; SpringAnimation { spring: 4; damping: 0.4 } }  
-      
+    Behavior on selectionWidth { enabled: root.animateSelection; SpringAnimation { spring: 4; damping: 0.4 } }
 
-    ShaderEffect {  
-        anchors.fill: parent  
-        z: 0  
-          
-        property vector4d selectionRect: Qt.vector4d(  
-            root.selectionX,  
-            root.selectionY,  
-            root.selectionWidth,  
-            root.selectionHeight  
-        )  
-        property real dimOpacity: root.dimOpacity  
-        property vector2d screenSize: Qt.vector2d(root.width, root.height)  
-        property real borderRadius: root.borderRadius  
-        property real outlineThickness: root.outlineThickness  
-          
-        fragmentShader: root.fragmentShader  
-    }  
 
-    Repeater {
-        model: root.windows
+    ShaderEffect {
+        anchors.fill: parent
+        z: 0
 
-        Item {
-            required property var modelData
+        property vector4d selectionRect: Qt.vector4d(
+            root.selectionX,
+            root.selectionY,
+            root.selectionWidth,
+            root.selectionHeight
+        )
+        property real dimOpacity: root.dimOpacity
+        property vector2d screenSize: Qt.vector2d(root.width, root.height)
+        property real borderRadius: root.borderRadius
+        property real outlineThickness: root.outlineThickness
 
-            Connections {
-                target: root
-
-                function onCheckHover(mouseX, mouseY) {
-                    // Retrieve window geometry from Hyprland IPC object
-                    if (!root.monitor || !root.monitor.lastIpcObject || !modelData.lastIpcObject)
-                        return;
-
-                    const monitorX = root.monitor.lastIpcObject.x
-                    const monitorY = root.monitor.lastIpcObject.y
-                    
-                    // Offset global coordinates by monitor position
-                    const windowX = modelData.lastIpcObject.at[0] - monitorX
-                    const windowY = modelData.lastIpcObject.at[1] - monitorY
-                    
-                    const width = modelData.lastIpcObject.size[0]
-                    const height = modelData.lastIpcObject.size[1]
-
-                    if (mouseX >= windowX && mouseX <= windowX + width && mouseY >= windowY && mouseY <= windowY + height) {
-                        selectionX = windowX
-                        selectionY = windowY
-                        selectionWidth = width
-                        selectionHeight = height
-                    }
-                }
-            }
-        }
+        fragmentShader: root.fragmentShader
     }
-      
-    MouseArea {  
-        id: mouseArea  
-        anchors.fill: parent  
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
         z: 3
         hoverEnabled: true
-          
-        onPositionChanged: (mouse) => { 
-            root.checkHover(mouse.x, mouse.y)
-        }  
-          
-        onReleased: (mouse) => {  
-            if (mouse.x >= root.selectionX && mouse.x <= root.selectionX + root.selectionWidth &&
-                mouse.y >= root.selectionY && mouse.y <= root.selectionY + root.selectionHeight) {
-                root.regionSelected(  
-                    Math.round(root.selectionX),  
-                    Math.round(root.selectionY),  
-                    Math.round(root.selectionWidth),  
-                    Math.round(root.selectionHeight)  
-                )  
-            }
-        }  
-    }  
+
+        onPositionChanged: (mouse) => {
+            root.mouseX = mouse.x;
+            root.mouseY = mouse.y;
+        }
+
+        onReleased: (mouse) => {
+            const hit = root.hitWindow(mouse.x, mouse.y);
+            if (!hit) return;
+            root.regionSelected(
+                Math.round(hit.x),
+                Math.round(hit.y),
+                Math.round(hit.w),
+                Math.round(hit.h)
+            );
+        }
+    }
 }

--- a/shell.qml
+++ b/shell.qml
@@ -19,7 +19,6 @@ Scope {
 
     property var hyprlandMonitor: Hyprland.focusedMonitor
     property string activeScreenName: hyprlandMonitor ? hyprlandMonitor.name : (Quickshell.screens.length > 0 ? Quickshell.screens[0].name : "")
-    property string tempPath: ""
     property string mode: ["region", "window"].indexOf(Quickshell.env("HQF_MODE")) !== -1 ? Quickshell.env("HQF_MODE") : "region"
     property var modes: ["edit", "region", "window", "temp"]
     property bool tempActive: Quickshell.env("HQF_ACTION") === "temp"
@@ -28,7 +27,6 @@ Scope {
     property int connectivityStatus: 0
     property string lastSavedPath: ""
     property string lastTimestamp: ""
-    property bool overlayVisible: false
     readonly property real targetMenuWidth: (modes.length - (editActive ? 1 : 0) - (tempActive ? 1 : 0)) * 100 + 8
     property var theme: themeObj
 
@@ -81,36 +79,15 @@ Scope {
         return "'" + s.replace(/'/g, "'\\''") + "'";
     }
 
-    function calculateCrop(x, y, width, height, screenName) {
-        let minX = Infinity;
-        let minY = Infinity;
-        let targetMonitor = null;
-        const monitors = Hyprland.monitors.values;
-        for (const m of monitors) {
-            minX = Math.min(minX, m.lastIpcObject.x);
-            minY = Math.min(minY, m.lastIpcObject.y);
-            if (m.name === screenName)
-                targetMonitor = m;
-
+    function grimGeometry(x, y, width, height, screenName) {
+        let target = null;
+        for (const m of Hyprland.monitors.values) {
+            if (m.name === screenName) { target = m; break; }
         }
-        if (!targetMonitor)
-            targetMonitor = hyprlandMonitor;
-
-        const scale = targetMonitor.scale;
-        const monitorX = targetMonitor.lastIpcObject.x;
-        const monitorY = targetMonitor.lastIpcObject.y;
-        const globalX = Math.round((x + monitorX) * scale);
-        const globalY = Math.round((y + monitorY) * scale);
-        return {
-            "cropX": globalX - Math.round(minX * scale),
-            "cropY": globalY - Math.round(minY * scale),
-            "scaledWidth": Math.round(width * scale),
-            "scaledHeight": Math.round(height * scale)
-        };
-    }
-
-    function cleanup() {
-        Quickshell.execDetached(["rm", "-f", tempPath]);
+        if (!target) target = hyprlandMonitor;
+        const mx = target.lastIpcObject.x;
+        const my = target.lastIpcObject.y;
+        return `${Math.round(x + mx)},${Math.round(y + my)} ${Math.round(width)}x${Math.round(height)}`;
     }
 
     function runPostSaveHook() {
@@ -130,32 +107,55 @@ Scope {
     }
 
     function saveScreenshot(x, y, width, height, screenName) {
-        const crop = calculateCrop(x, y, width, height, screenName);
+        const geom = grimGeometry(x, y, width, height, screenName);
         const picturesBase = Quickshell.env("XDG_PICTURES_DIR") || (Quickshell.env("HOME") + "/Pictures");
         const picturesDir = picturesBase + "/Screenshots";
-        const now = new Date();
-        const timestamp = Qt.formatDateTime(now, "yyyy-MM-dd_hh-mm-ss");
+        const timestamp = Qt.formatDateTime(new Date(), "yyyy-MM-dd_hh-mm-ss");
         const outputPath = `${picturesDir}/screenshot-${timestamp}.png`;
         root.lastTimestamp = timestamp;
         root.lastSavedPath = root.tempActive ? "" : outputPath;
-        const tempSnip = Quickshell.cachePath(`snip-${timestamp}.png`);
         const ePicturesDir = shellEscape(picturesDir);
         const eOutputPath = shellEscape(outputPath);
-        const eTempPath = shellEscape(tempPath);
-        const eTempSnip = shellEscape(tempSnip);
-        const shareCmd = "kdeconnect-cli -l | grep 'reachable' | grep -oP '[a-f0-9-]{8,}'" + " | head -1 | xargs -I{} sh -c" + " 'kdeconnect-cli -d {} --share \"$1\" && sleep 0.2" + " && kdeconnect-cli -d {} --send-clipboard' --";
-        const maybeShare = (escapedPath) => {
-            return root.shareActive ? ` && ${shareCmd} ${escapedPath}` : "";
-        };
+        const eGeom = shellEscape(geom);
+
+        const grimRegion = `timeout 5 grim -l 1 -g ${eGeom}`;
+
+        const shareCmd = "kdeconnect-cli -l | grep 'reachable' | grep -oP '[a-f0-9-]{8,}'"
+            + " | head -1 | xargs -I{} sh -c"
+            + " 'kdeconnect-cli -d {} --share \"$1\" && sleep 0.2"
+            + " && kdeconnect-cli -d {} --send-clipboard' --";
+        const maybeShare = (escapedPath) => root.shareActive ? ` && ${shareCmd} ${escapedPath}` : "";
         const shareTag = root.shareActive ? " & phone" : "";
         const mkdirCmd = `mkdir -p ${ePicturesDir}`;
-        const cropCmd = `magick ${eTempPath} -crop ` + `${crop.scaledWidth}x${crop.scaledHeight}` + `+${crop.cropX}+${crop.cropY} +repage`;
-        const sattyCommand = `${mkdirCmd} && ${cropCmd} png:- ` + `| satty --filename - ` + `--output-filename ${eOutputPath} --early-exit --init-tool brush ` + `&& wl-copy --type image/png < ${eOutputPath}` + `${maybeShare(eOutputPath)}; rm -f ${eTempPath}`;
-        const gradiaCommand = `${mkdirCmd} && ${cropCmd} ${eOutputPath} && hyprctl dispatch exec -- "gradia ${eOutputPath} || flatpak run be.alexandervanhee.gradia ${eOutputPath}"; sleep 0.5; rm -f ${eTempPath}`;
-        const defaultSaveCommand = `${mkdirCmd} && ${cropCmd} ${eOutputPath} ` + `&& wl-copy --type image/png < ${eOutputPath}` + `${maybeShare(eOutputPath)} ` + `&& notify-send -a "HyprQuickFrame" -i ${eOutputPath} ` + `-h string:image-path:${eOutputPath} "Screenshot Saved" ` + `"Saved to ${picturesDir}"; rm -f ${eTempPath}`;
-        const defaultTempCommand = `${cropCmd} ${eTempSnip} ` + `&& wl-copy --type image/png < ${eTempSnip}` + `${maybeShare(eTempSnip)} ` + `&& notify-send -a "HyprQuickFrame" "Screenshot Copied" ` + `"Copied to clipboard${shareTag}"; ` + `rm -f ${eTempPath} ${eTempSnip}`;
+
+        const sattyCommand =
+            `${mkdirCmd} && ${grimRegion} - `
+            + `| satty --filename - --output-filename ${eOutputPath} --early-exit --init-tool brush `
+            + `&& wl-copy --type image/png < ${eOutputPath}`
+            + `${maybeShare(eOutputPath)}`;
+        const gradiaCommand =
+            `${mkdirCmd} && ${grimRegion} ${eOutputPath} `
+            + `&& hyprctl dispatch exec -- "gradia ${eOutputPath} || flatpak run be.alexandervanhee.gradia ${eOutputPath}"`;
+        const defaultSaveCommand =
+            `${mkdirCmd} && ${grimRegion} ${eOutputPath} `
+            + `&& wl-copy --type image/png < ${eOutputPath}`
+            + `${maybeShare(eOutputPath)} `
+            + `&& notify-send -a "HyprQuickFrame" -i ${eOutputPath} `
+            + `-h string:image-path:${eOutputPath} "Screenshot Saved" `
+            + `"Saved to ${picturesDir}"`;
+        const eTempSnip = shellEscape(Quickshell.cachePath(`snip-${timestamp}.png`));
+        const tempShareCommand =
+            `${grimRegion} ${eTempSnip} `
+            + `&& wl-copy --type image/png < ${eTempSnip}`
+            + `${maybeShare(eTempSnip)} `
+            + `&& notify-send -a "HyprQuickFrame" "Screenshot Copied" "Copied to clipboard${shareTag}"; `
+            + `rm -f ${eTempSnip}`;
+        const tempPlainCommand =
+            `${grimRegion} - | wl-copy --type image/png `
+            + `&& notify-send -a "HyprQuickFrame" "Screenshot Copied" "Copied to clipboard"`;
+        const defaultTempCommand = root.shareActive ? tempShareCommand : tempPlainCommand;
+
         let cmd;
-        console.log("Evaluated annotationTool value:", theme.annotationTool);
         if (root.editActive)
             cmd = theme.annotationTool === "gradia" ? gradiaCommand : sattyCommand;
         else if (root.tempActive)
@@ -164,30 +164,23 @@ Scope {
             cmd = defaultSaveCommand;
         screenshotProcess.command = ["sh", "-c", cmd];
         screenshotProcess.running = true;
-        root.overlayVisible = false;
     }
 
     Component.onCompleted: {
-        const timestamp = Date.now();
-        const rand = Math.floor(Math.random() * 100000);
-        const path = Quickshell.cachePath(`screenshot-${timestamp}-${rand}.png`);
-        tempPath = path;
-        captureProcess.command = ["grim", "-l", "0", path];
-        captureProcess.running = true;
         connectivityProcess.running = true;
+        readyWatchdog.start();
     }
 
-    Process {
-        id: captureProcess
-
-        running: false
-        onExited: (code) => {
-            if (code === 0) {
-                showTimer.start();
-            } else {
-                cleanup();
-                Qt.quit();
+    Timer {
+        id: readyWatchdog
+        interval: 4000
+        repeat: false
+        onTriggered: {
+            for (const w of overlayVariants.instances) {
+                if (w && w.isReady) return;
             }
+            console.error("HyprQuickFrame: screencopy never produced a frame; exiting.");
+            Qt.quit();
         }
     }
 
@@ -234,15 +227,6 @@ Scope {
 
     }
 
-    Timer {
-        id: showTimer
-
-        interval: 50
-        running: false
-        repeat: false
-        onTriggered: root.overlayVisible = true
-    }
-
     Process {
         id: screenshotProcess
 
@@ -276,13 +260,14 @@ Scope {
     Process {
         id: connectivityProcess
 
-        command: ["sh", "-c", "kdeconnect-cli -l | grep 'reachable'"]
+        command: ["sh", "-c", "timeout 2 kdeconnect-cli -l | grep 'reachable'"]
         onExited: (code) => {
             root.connectivityStatus = (code === 0 ? 1 : 2);
         }
     }
 
     Variants {
+        id: overlayVariants
         model: Quickshell.screens
 
         FreezeScreen {
@@ -302,11 +287,10 @@ Scope {
             }
 
             targetScreen: modelData
-            visible: root.overlayVisible
-            onVisibleChanged: {
-                if (visible && isFocused)
+            visible: true
+            Component.onCompleted: {
+                if (isFocused)
                     cursorPosProcess.running = true;
-
             }
 
             Process {
@@ -334,10 +318,7 @@ Scope {
 
             Shortcut {
                 sequences: ["Escape", "q"]
-                onActivated: {
-                    root.cleanup();
-                    Qt.quit();
-                }
+                onActivated: Qt.quit()
             }
 
             Shortcut {


### PR DESCRIPTION
Pressing the keybind kicks off `grim -l 0` to dump the whole screen,
and the overlay sits invisible until grim returns. On NVIDIA,
wlr-screencopy sometimes stalls and grim never comes back. Six-minute
hang on a real session. Esc can't kill grim while it's stuck like
that, so each keypress leaks an orphan, which is why the tool feels
slower the more you use it.

The freeze visual already comes from ScreencopyView, so the upfront
grim and the magick crop on save only existed to feed each other. I
dropped both. The window shows on frame one and `saveScreenshot`
calls `grim -g <region>` once, no magick. Grim and kdeconnect-cli are
wrapped in `timeout` so they fail fast. A 4s watchdog quits if no
FreezeScreen ever produces a frame. Temp/clipboard streams
`grim - | wl-copy` straight through.

Two cleanups while I was in there. RegionSelector was drawing the
crosshair on a Canvas with requestPaint on every mouse move; swapped
it for 1px Rectangles. The spring on selection* was rubber-banding
the box behind the cursor, and on release selection* could be
mid-flight so the captured region was wrong. Spring's still on for
clear/cancel, off during drag.

WindowSelector was running its hit test through a Repeater spawning
per-window Connections listening to a multicast signal. Replaced with
one hitWindow loop. onReleased recomputes from the mouse position
instead of trusting selection*.

Tested on Hyprland 0.54.3, GTX 980, two monitors at 1.25x. Region,
window, full-screen, edit through satty, temp, share all work.
Overlay's instant now, no grim orphans after many opens.